### PR TITLE
Set width to 100px by default

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -110,8 +110,26 @@ function addImageToSlide(imageBlob, title) {
   var presentation = SlidesApp.getActivePresentation();
   var currentPage = presentation.getSelection().getCurrentPage();
   
-  currentPage.insertImage(imageBlob);
+  var insertedImage = currentPage.insertImage(imageBlob);
   // No option to set a title on an Image in Slide
+  
+  // Limit inserted image size to 300px max at insertion time
+  var maxSize = 300,
+    width = insertedImage.getWidth(),
+    height = insertedImage.getHeight(),
+    ratio = width / height;
+  
+  if (ratio > 1) {
+    width = maxSize;
+    height = maxSize / ratio;
+  }
+  else {
+    width = maxSize * ratio;
+    height = maxSize;
+  }
+  
+  insertedImage.setWidth(width);
+  insertedImage.setHeight(height);
   
   presentation.saveAndClose();
 }
@@ -143,12 +161,23 @@ function addImageToDoc(imageBlob, title) {
     insertedImage = doc.getBody().appendImage(imageBlob);
   }
   
-  var width = insertedImage.getWidth();
-  var height = insertedImage.getHeight();
-  var ratio = width / height;
-  var newWidth = 100;
-  insertedImage.setWidth(newWidth);
-  insertedImage.setHeight(newWidth * ratio);
+  // Limit inserted image size to 100px max at insertion time
+  var maxSize = 100,
+    width = insertedImage.getWidth(),
+    height = insertedImage.getHeight(),
+    ratio = width / height;
+  
+  if (ratio > 1) {
+    width = maxSize;
+    height = maxSize / ratio;
+  }
+  else {
+    width = maxSize * ratio;
+    height = maxSize;
+  }
+  
+  insertedImage.setWidth(width);
+  insertedImage.setHeight(height);
   
   // Set title if provided
   title && insertedImage.setAltTitle(title);


### PR DESCRIPTION
If needed, user can increase the size himself but let's assume an icon is usually used in a small format, not taking the whole document width.